### PR TITLE
Gymnasium entry_points fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ examples_requires = [
 ]
 
 entry_points = {
-    'gym.envs': ['MinAtar=minatar.gym:register_envs']
+    'gymnasium.envs': ['MinAtar=minatar.gym:register_envs']
 }
 
 setup(


### PR DESCRIPTION
Hello, 
first of all, thank you for putting together that awesome repository for all the Atari emulators.

Unfortunately, when cloning your repository, I was not able to create the environments with gymnasium and `gymnasium.make('MinAtar/...').  After some debugging, I figured out that the namespace for registering the MinAtar environments was still pointing to the old gym entrypoint instead of gymnasium. 

It would be nice if you accept the pull request which fixes that issue. With that you can use gymnasium out of the box with minatar without additional tweaks in the site-packages.