### PR TITLE
obs space from bool to uint

### DIFF
--- a/minatar/gym.py
+++ b/minatar/gym.py
@@ -31,7 +31,7 @@ class BaseEnv(gym.Env):
 
         self.action_space = spaces.Discrete(len(self.action_set))
         self.observation_space = spaces.Box(
-            0.0, 1.0, shape=self.game.state_shape(), dtype=bool
+            0, 1, shape=self.game.state_shape(), dtype=np.uint8
         )
 
     def step(self, action):


### PR DESCRIPTION
Observation space is now of dtype uint8 rather than bool. This is consistent with gym/gymnasium obs spaces. There will still be a warning saying that the upper bound is not 255, but it can be disabled with `gym.make(name, disable_env_checker=True)`