### PR TITLE
GRAD_MOMENTUM not used by RMSProp in DQN

### DIFF
--- a/examples/dqn.py
+++ b/examples/dqn.py
@@ -42,7 +42,6 @@ FIRST_N_FRAMES = 100000
 REPLAY_START_SIZE = 5000
 END_EPSILON = 0.1
 STEP_SIZE = 0.00025
-GRAD_MOMENTUM = 0.95
 SQUARED_GRAD_MOMENTUM = 0.95
 MIN_SQUARED_GRAD = 0.01
 GAMMA = 0.99
@@ -280,7 +279,7 @@ def dqn(env, replay_off, target_off, output_file_name, store_intermediate_result
         r_buffer = replay_buffer(REPLAY_BUFFER_SIZE)
         replay_start_size = REPLAY_START_SIZE
 
-    optimizer = optim.RMSprop(policy_net.parameters(), lr=step_size, alpha=SQUARED_GRAD_MOMENTUM, centered=True, eps=MIN_SQUARED_GRAD, momentum=GRAD_MOMENTUM)
+    optimizer = optim.RMSprop(policy_net.parameters(), lr=step_size, alpha=SQUARED_GRAD_MOMENTUM, centered=True, eps=MIN_SQUARED_GRAD)
 
     # Set initial values
     e_init = 0

--- a/examples/dqn.py
+++ b/examples/dqn.py
@@ -280,7 +280,7 @@ def dqn(env, replay_off, target_off, output_file_name, store_intermediate_result
         r_buffer = replay_buffer(REPLAY_BUFFER_SIZE)
         replay_start_size = REPLAY_START_SIZE
 
-    optimizer = optim.RMSprop(policy_net.parameters(), lr=step_size, alpha=SQUARED_GRAD_MOMENTUM, centered=True, eps=MIN_SQUARED_GRAD)
+    optimizer = optim.RMSprop(policy_net.parameters(), lr=step_size, alpha=SQUARED_GRAD_MOMENTUM, centered=True, eps=MIN_SQUARED_GRAD, momentum=GRAD_MOMENTUM)
 
     # Set initial values
     e_init = 0


### PR DESCRIPTION
I noticed that `GRAD_MOMENTUM` on the following line is never used:

https://github.com/kenjyoung/MinAtar/blob/1918a2f165307ff516640ef418ed2f9f66ad8840/examples/dqn.py#L45

I think this is likely a bug, since the default momentum for Pytorch's RMSProp is 0 and not 0.95 (see [docs](https://pytorch.org/docs/stable/generated/torch.optim.RMSprop.html)).
This PR fixes it by passing the value into the optimizer constructor.